### PR TITLE
Grammar edits, reorder OSes, and add a new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ The developers or publishers of these open-source operating systems have decided
 #### Other Operating Systems
 | &nbsp; | Operating System | Notes |
 | - | - | - |
-| :no_entry: | **EndeavorOS Linux** | [Developer statement](https://x.com/LundukeJournal/status/2037393956384674196) |
 | :no_entry: | **FreeDOS** | [Developer statement](https://x.com/lundukejournal/status/2034770975309361583) |
 
 ### Operating Systems Planning to Implement Age Verification

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-This page is a running list of Open Source Operating Systems (Linux & *BSD distributions, etc.) and what their current status is regarding age verification.
+This page is a running list of Open-Source Operating Systems (Linux Distros & BSDs, etc.) and their current status regarding age verification.
 
-There are several locales which have laws (in various stages) which require Operating Systems themselves to perform some level of age verification and reporting.
+Several locales have laws (in various stages) that require Operating Systems themselves to perform some level of age verification and reporting.
 
 Passed OS-Level Age Verification Laws: [Brazil](https://x.com/lundukejournal/status/2033927808196481101), & [California](https://x.com/lundukejournal/status/2026783141298360692).
 
@@ -8,39 +8,51 @@ Proposed OS-Level Age Verification Laws: [Colorado](https://x.com/lundukejournal
 
 ### Operating Systems Not Implementing Age Verification
 
-The developers or publishers of these open source Operating Systems have decided to not implement Age Verification, or are currently restricting access in regions with Age Verification laws.
+The developers or publishers of these open-source operating systems have decided not to implement age verification or are currently restricting access in regions with Age Verification laws.
 
+#### Linux Distros
 | &nbsp; | Operating System | Notes |
 | - | - | - |
-| :no_entry: | **Omarchy Linux** | [Developer statement](https://x.com/lundukejournal/status/2029580164498108846) |
-| :no_entry: | **Devuan Linux** | [Developer statement](https://x.com/lundukejournal/status/2034697759291310115) |
-| :no_entry: | **Slackware Linux** | [Developer statement](https://x.com/LundukeJournal/status/2036520144239743302) |
-| :no_entry: | **Zorin OS** | [Developer statement](https://x.com/LundukeJournal/status/2038282756715589738) |
-| :no_entry: | **Vendefoul Wolf Linux** | [Developer statement 1](https://x.com/lundukejournal/status/2035390136356077822), [2](https://x.com/vendefoulwolf/status/2035441292520386852) |
-| :no_entry: | **GrapheneOS** | Android-based mobile OS, [Developer statement](https://x.com/lundukejournal/status/2035073741613338964) |
-| :no_entry: | **FreeDOS** | [Developer statement](https://x.com/lundukejournal/status/2034770975309361583) |
-| :no_entry: | **Artix Linux** | [Developer statement](https://x.com/lundukejournal/status/2034776326901555488) |
-| :no_entry: | **DB48X** | Calculator firmware, [Developer statement](https://x.com/lundukejournal/status/2027358439991615715) |
-| :no_entry: | **Arch Linux 32** | [Developer forbids usage in Brazil, California](https://x.com/lundukejournal/status/2033896030178029675) |
 | :no_entry: | **Ageless Linux** | [Debian fork created to protest Age Verification](https://x.com/lundukejournal/status/2032951803134837237) |
-| :no_entry: | **Garuda Linux** | [Developer statement](https://x.com/LundukeJournal/status/2036164910699188456) |
-| :no_entry: | **Void Linux** | [Developer statement](https://x.com/LundukeJournal/status/2036521455752495439) |
+| :no_entry: | **Arch Linux 32** | [Developer forbids usage in Brazil, California](https://x.com/lundukejournal/status/2033896030178029675) |
+| :no_entry: | **Artix Linux** | [Developer statement](https://x.com/lundukejournal/status/2034776326901555488) |
+| :no_entry: | **Devuan Linux** | [Developer statement](https://x.com/lundukejournal/status/2034697759291310115) |
 | :no_entry: | **EndeavorOS Linux** | [Developer statement](https://x.com/LundukeJournal/status/2037393956384674196) |
+| :no_entry: | **Garuda Linux** | [Developer statement](https://x.com/LundukeJournal/status/2036164910699188456) |
+| :no_entry: | **Omarchy Linux** | [Developer statement](https://x.com/lundukejournal/status/2029580164498108846) |
+| :no_entry: | **OpenMandriva Linux** | [Developer Statement](https://forum.openmandriva.org/t/systemd-adds-age-verification-are-you-serious/8793/75?u=xseagdc) |
+| :no_entry: | **Slackware Linux** | [Developer statement](https://x.com/LundukeJournal/status/2036520144239743302) |
+| :no_entry: | **Vendefoul Wolf Linux** | [Developer statement 1](https://x.com/lundukejournal/status/2035390136356077822), [2](https://x.com/vendefoulwolf/status/2035441292520386852) |
+| :no_entry: | **Void Linux** | [Developer statement](https://x.com/LundukeJournal/status/2036521455752495439) |
+| :no_entry: | **Zorin OS** | [Developer statement](https://x.com/LundukeJournal/status/2038282756715589738) |
+#### BSDs
+| &nbsp; | Operating System | Notes |
+| - | - | - |
+| :no_entry: | **GhostBSD** | [Developer Statement](https://forums.ghostbsd.org/d/793-freebsd-and-age-verification) |
+#### Mobile-Focused Operating Systems
+| &nbsp; | Operating System | Notes |
+| - | - | - |
+| :no_entry: | **DB48X** | Calculator firmware, [Developer statement](https://x.com/lundukejournal/status/2027358439991615715) |
+| :no_entry: | **GrapheneOS** | Android-based, [Developer statement](https://x.com/lundukejournal/status/2035073741613338964) |
+#### Other Operating Systems
+| &nbsp; | Operating System | Notes |
+| - | - | - |
+| :no_entry: | **FreeDOS** | [Developer statement](https://x.com/lundukejournal/status/2034770975309361583) |
 
 ### Operating Systems Planning to Implement Age Verification
 
-The developers or publishers of these Open Source Operating Systems have made plans and/or statements that they intend to comply with new Age Verification laws.  But, as yet, that Age Verfication functionality is not fully implemented.
+The developers or publishers of these Open Source Operating Systems have made plans and/or statements that they intend to comply with the new Age Verification laws.  But, as yet, that Age Verification functionality is not fully implemented.
 
 | &nbsp; | Operating System | Notes |
 | - | - | - |
-| :building_construction: | **Ubuntu** | [Planning Discussion](https://lists.ubuntu.com/archives/ubuntu-devel/2026-March/043510.html), [Ubuntu VP Statement](https://x.com/lundukejournal/status/2029198322309681311) |
-| :building_construction: | **Pop!_OS** | [System76 Statement opposing, but planning to implement](https://blog.system76.com/post/system76-on-age-verification) |
 | :building_construction: | **elementary OS** | [Founder Statement planning to implement](https://mastodon.social/@danirabbit@mastodon.online/116250766314705297) |
-| :building_construction: | **Fedora** | [Planning Discussion](https://x.com/LundukeJournal/status/2036526650154729543) |
+| :building_construction: | **Fedora** | [Planning Discussion](https://x.com/LundukeJournal/status/2036526650154729543) 
+| :building_construction: | **Pop!_OS** | [System76 Statement opposing, but planning to implement](https://blog.system76.com/post/system76-on-age-verification) |
+| :building_construction: | **Ubuntu** | [Planning Discussion](https://lists.ubuntu.com/archives/ubuntu-devel/2026-March/043510.html), [Ubuntu VP Statement]|(https://x.com/lundukejournal/status/2029198322309681311) |
 
 ### Uncertain Age Verification Future
 
-The developers or publishers of these open source Operating Systems have made statements which are confusing, nebulous, or suggest that they may (or may not) ship with Age Verification in the future.
+The developers or publishers of these open source Operating Systems have made confusing statements, nebulous statements, or suggested that they may (or may not) ship with Age Verification in the future.
 
 | &nbsp; | Operating System | Notes |
 | - | - | - |
@@ -49,7 +61,7 @@ The developers or publishers of these open source Operating Systems have made st
 
 ### Operating Systems Which Have Already Implemented Age Verification
 
-The following Operating Systems have officially added default Age Verification (or Age Attestation) functionality to their primary released released version.
+The following Operating Systems have officially added default Age Verification (or Age Attestation) functionality to their primary released version.
 
 | &nbsp; | Operating System | Notes |
 | - | - | - |


### PR DESCRIPTION
Fix grammar, rearrange OSes alphabetically, divide them into subcategories, and add OpenMandriva & GhostBSD to "No to Age Verification."