### PR TITLE
Add Zorin OS developer statement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The developers or publishers of these open source Operating Systems have decided
 | :no_entry: | **EndeavorOS Linux** | [Developer statement](https://x.com/LundukeJournal/status/2037393956384674196) |
 | :no_entry: | **GhostBSD** | [Developer statement](https://x.com/LundukeJournal/status/2039064364712345729) |
 | :no_entry: | **Parrot OS** | [Developer statement](https://x.com/LundukeJournal/status/2040148333185180125) |
+| :no_entry: | **Zorin OS** | [Developer statement](https://forum.zorin.com/t/statement-about-age-verification-laws/61052) |
 
 ### Operating Systems Planning to Implement Age Verification
 


### PR DESCRIPTION
Added Zorin OS developer statement on age verification laws to README

[official statement](https://forum.zorin.com/t/statement-about-age-verification-laws/61052)

**Artyom Zorin**:

We have no plans to introduce mandatory age or ID verification into Zorin OS.
As privacy and security are core values of Zorin OS, we're closely monitoring the unfortunate trend of new OS-level age verification laws and evaluating how we could avoid them infringing on our users' rights.