### PR TITLE
included vipnix liveCD

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The developers or publishers of these open source Operating Systems have decided
 | :no_entry: | **EndeavorOS Linux** | [Developer statement](https://x.com/LundukeJournal/status/2037393956384674196) |
 | :no_entry: | **GhostBSD** | [Developer statement](https://x.com/LundukeJournal/status/2039064364712345729) |
 | :no_entry: | **Parrot OS** | [Developer statement](https://x.com/LundukeJournal/status/2040148333185180125) |
+| :no_entry: | **Vipnix Linux** | [Developer statement](https://vipnix.com.br/site/livecd-vipnix/) |
+
 
 ### Operating Systems Planning to Implement Age Verification
 


### PR DESCRIPTION
included Vipnix Linux.

https://vipnix.com.br/site/livecd-vipnix/

 Vipnix Linux chose to refuse implementing age verification, even though it was developed in Brazil, and instead opted to prohibit its use and distribution by Brazilian users.

Read: 

Legal Notice: Due to recent legislative changes, specifically Brazilian Law No. 15.211/2025 (Digital ECA) and/or California law AB 1043, this project currently does not allow you to download the VIPNIX LiveCD in these jurisdictions. VIPNIX LiveCD is a Linux system created by VIPNIX since 2011, in Brazilian territory, by a Brazilian company.

As a community-driven Free and Open Source Software (FOSS) project, we do not have the legal infrastructure nor the financial resources to implement the “auditable age verification” and “identity verification” mechanisms required by these laws, and we also have no intention of modifying VIPNIX LiveCD to comply with such legal requirements.

To avoid catastrophic fines that could permanently shut down this project globally, we have been forced to implement this regional restriction.

What this means for you: The download, distribution, and modification of the distributed source code is prohibited for residents of Brazil and for residents of California/USA.

This means that any operating system publicly distributed in Brazil, under this interpretation of law Felca (15.211/2025), would need to incorporate some form of user identification, data collection, or age validation before allowing the system to be used. For those who have worked for decades with open source software, privacy and user autonomy are essential, and this new legislation simply destroys the purpose of a Linux LiveCD.

Vipnix LiveCD was created to be exactly the opposite of that. It was designed so that anyone can download the ISO, write it to a USB drive, boot a computer, and use it immediately, without registration, without data collection, without mandatory login, and without any form of surveillance, with full access to the source code for auditing and modification. Alongside the LiveCD, I distribute a VIPNIX tool specifically to facilitate building our Linux from source code. It is a free, portable, and transparent environment, exactly as the original spirit of open source has always defended.

Implementing an age verification system in a LiveCD makes no technical sense. A LiveCD is not a centralized service, does not have pre-registered user accounts, has no backend infrastructure, and does not depend on external servers to function. It is simply an operating system that runs locally on the user’s machine. Requiring age verification in this context is equivalent to requiring that a hammer verifies the age of the person holding it.

Beyond the technical impossibility, there is also an ethical issue. Vipnix has always defended systems that respect user privacy. Introducing any form of mandatory identification would directly violate this principle. It would turn a free open source system into a surveillance platform, something we will never accept.

Therefore, faced with this absurd requirement, the only legal alternative to avoid regulatory issues in Brazil is to officially restrict the use and distribution of Vipnix LiveCD for Brazilian users.

It is important to clarify that the VIPNIX LiveCD project will continue to exist, continue to be developed, and remain available to the rest of the world. The code will remain open, the community will continue to contribute, and the system will continue to evolve. The only change is the inability to distribute it to Brazil while this legislation remains in its current form.

It is unfortunate to see a country that once had such a strong open source community moving toward rules that make independent projects unviable. A Linux LiveCD is simply a free operating system, nowhere near being a social network, a mobile app, or a content platform.

I sincerely hope this situation will be revisited in the future. Until then, unfortunately, to legally protect Vipnix, access to the LiveCD for Brazilian users will have to be officially blocked.