### PR TITLE
Add direct URLs wherever applicable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@ This page is a running list of Open Source Operating Systems (Linux & *BSD distr
 
 There are several locales which have laws (in various stages) which require Operating Systems themselves to perform some level of age verification and reporting.
 
-Passed OS-Level Age Verification Laws: [Brazil](https://x.com/lundukejournal/status/2033927808196481101), & [California](https://x.com/lundukejournal/status/2026783141298360692).
+Passed OS-Level Age Verification Laws: [Brazil](https://www.planalto.gov.br/ccivil_03/_ato2023-2026/2025/Lei/L15211.htm) ([𝕏](https://x.com/lundukejournal/status/2033927808196481101)), & [California](https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202520260AB1043) ([𝕏](https://x.com/lundukejournal/status/2026783141298360692)).
 
-Proposed OS-Level Age Verification Laws: [U.S. Federal Law](https://x.com/LundukeJournal/status/2044163936040411388), [Colorado](https://x.com/lundukejournal/status/2026331487499370988), [Illinois](https://x.com/lundukejournal/status/2031047619225493597), & [New York](https://x.com/lundukejournal/status/2029081398577922173).
+Proposed OS-Level Age Verification Laws: [U.S. Federal Law](https://www.congress.gov/bill/119th-congress/house-bill/8250/all-info) ([𝕏](https://x.com/LundukeJournal/status/2044163936040411388)), [Colorado](https://leg.colorado.gov/bills/SB26-051) ([𝕏](https://x.com/lundukejournal/status/2026331487499370988)), [Illinois](https://www.ilga.gov/Legislation/BillStatus/FullText?GAID=18&DocNum=3977&DocTypeID=SB&LegId=167475&SessionID=114) ([𝕏](https://x.com/lundukejournal/status/2031047619225493597)), & [New York](https://www.nysenate.gov/legislation/bills/2025/S8102/amendment/A) ([𝕏](https://x.com/lundukejournal/status/2029081398577922173)).
 
-Withdrawn OS-Level Age Verification Laws: [Michigan](https://x.com/LundukeJournal/status/2043143300756984045)
+Withdrawn OS-Level Age Verification Laws: [Michigan](https://www.thecentersquare.com/michigan/article_7ca4e268-4a68-42fb-9042-f9d8604ebd7f.html) ([𝕏](https://x.com/LundukeJournal/status/2043143300756984045)).
 
 ### Operating Systems Not Implementing Age Verification
 
@@ -15,21 +15,21 @@ The developers or publishers of these open source Operating Systems have decided
 | &nbsp; | Operating System | Notes |
 | - | - | - |
 | :no_entry: | **Omarchy Linux** | [Developer statement](https://x.com/lundukejournal/status/2029580164498108846) |
-| :no_entry: | **Devuan Linux** | [Developer statement](https://x.com/lundukejournal/status/2034697759291310115) |
-| :no_entry: | **Slackware Linux** | [Developer statement](https://x.com/LundukeJournal/status/2036520144239743302) |
-| :no_entry: | **Zorin OS** | [Developer statement](https://x.com/LundukeJournal/status/2038282756715589738) |
-| :no_entry: | **Vendefoul Wolf Linux** | [Developer statement 1](https://x.com/lundukejournal/status/2035390136356077822), [2](https://x.com/vendefoulwolf/status/2035441292520386852) |
-| :no_entry: | **GrapheneOS** | Android-based mobile OS, [Developer statement](https://x.com/lundukejournal/status/2035073741613338964) |
+| :no_entry: | **Devuan Linux** | [Developer statement](https://x.com/jaromil/status/2034694340249821329) ([𝕏](https://x.com/lundukejournal/status/2034697759291310115)) |
+| :no_entry: | **Slackware Linux** | [Developer statement](https://www.linuxquestions.org/questions/showthread.php?p=6626190) ([𝕏](https://x.com/LundukeJournal/status/2036520144239743302)) |
+| :no_entry: | **Zorin OS** | [Developer statement](https://forum.zorin.com/t/statement-about-age-verification-laws/61052) ([𝕏](https://x.com/LundukeJournal/status/2038282756715589738)) |
+| :no_entry: | **Vendefoul Wolf Linux** | [Developer statement](https://x.com/vendefoulwolf/status/2035441292520386852) ([𝕏](https://x.com/lundukejournal/status/2035390136356077822)) |
+| :no_entry: | **GrapheneOS** | Android-based mobile OS, [Developer statement](https://x.com/GrapheneOS/status/2034957604682621229) ([𝕏](https://x.com/lundukejournal/status/2035073741613338964)) |
 | :no_entry: | **FreeDOS** | [Developer statement](https://x.com/lundukejournal/status/2034770975309361583) |
-| :no_entry: | **Artix Linux** | [Developer statement](https://x.com/lundukejournal/status/2034776326901555488) |
-| :no_entry: | **DB48X** | Calculator firmware, [Developer statement](https://x.com/lundukejournal/status/2027358439991615715) |
-| :no_entry: | **Arch Linux 32** | [Developer forbids usage in Brazil, California](https://x.com/lundukejournal/status/2033896030178029675) |
-| :no_entry: | **Ageless Linux** | [Debian fork created to protest Age Verification](https://x.com/lundukejournal/status/2032951803134837237) |
-| :no_entry: | **Garuda Linux** | [Developer statement](https://x.com/LundukeJournal/status/2036164910699188456) |
-| :no_entry: | **Void Linux** | [Developer statement](https://x.com/LundukeJournal/status/2036521455752495439) |
-| :no_entry: | **EndeavorOS Linux** | [Developer statement](https://x.com/LundukeJournal/status/2037393956384674196) |
-| :no_entry: | **GhostBSD** | [Developer statement](https://x.com/LundukeJournal/status/2039064364712345729) |
-| :no_entry: | **Parrot OS** | [Developer statement](https://x.com/LundukeJournal/status/2040148333185180125) |
+| :no_entry: | **Artix Linux** | [Developer statement](https://forum.artixlinux.org/index.php/topic,9304.msg55607.html#msg55607) ([𝕏](https://x.com/lundukejournal/status/2034776326901555488)) |
+| :no_entry: | **DB48X** | Calculator firmware, [Developer statement](https://github.com/c3d/db48x/blob/stable/LEGAL-NOTICE.md) ([𝕏](https://x.com/lundukejournal/status/2027358439991615715)) |
+| :no_entry: | **Arch Linux 32** | [Developer forbids usage in Brazil, California](https://pbs.twimg.com/media/HDnuuw6bEAItjg7?format=jpg) ([𝕏](https://x.com/lundukejournal/status/2033896030178029675)) |
+| :no_entry: | **Ageless Linux** | [Debian fork created to protest Age Verification](https://agelesslinux.org/) ([𝕏](https://x.com/lundukejournal/status/2032951803134837237)) |
+| :no_entry: | **Garuda Linux** | [Developer statement](https://forum.garudalinux.org/t/a-statement-on-age-verification-the-state-of-the-community-discourse/47652) ([𝕏](https://x.com/LundukeJournal/status/2036164910699188456)) |
+| :no_entry: | **Void Linux** | [Developer statement](https://old.reddit.com/r/voidlinux/comments/1ryhgpl/systemd_adds_age_attestation_effecting_almost/obeigup/) ([𝕏](https://x.com/LundukeJournal/status/2036521455752495439)) |
+| :no_entry: | **EndeavourOS** | [Developer statement](https://endeavouros.com/news/whats-new-in-endeavouros-titan-release/) ([𝕏](https://x.com/LundukeJournal/status/2037393956384674196)) |
+| :no_entry: | **GhostBSD** | [Developer statement](https://forums.ghostbsd.org/d/793-freebsd-and-age-verification/37) ([𝕏](https://x.com/LundukeJournal/status/2039064364712345729)) |
+| :no_entry: | **Parrot OS** | [Developer statement](https://parrotsec.org/blog/2026-04-02-our-statement-about-age-verification/) ([𝕏](https://x.com/LundukeJournal/status/2040148333185180125)) |
 
 ### Operating Systems Planning to Implement Age Verification
 
@@ -37,11 +37,11 @@ The developers or publishers of these Open Source Operating Systems have made pl
 
 | &nbsp; | Operating System | Notes |
 | - | - | - |
-| :building_construction: | **Ubuntu** | [Planning Discussion](https://lists.ubuntu.com/archives/ubuntu-devel/2026-March/043510.html), [Ubuntu VP Statement](https://x.com/lundukejournal/status/2029198322309681311) |
+| :building_construction: | **Ubuntu** | [Planning Discussion](https://lists.ubuntu.com/archives/ubuntu-devel/2026-March/043510.html), [Ubuntu VP Statement](https://discourse.ubuntu.com/t/ubuntus-response-to-californias-digital-age-assurance-act-ab-1043/77948) ([𝕏](https://x.com/lundukejournal/status/2029198322309681311)) |
 | :building_construction: | **Pop!_OS** | [System76 Statement opposing, but planning to implement](https://blog.system76.com/post/system76-on-age-verification) |
 | :building_construction: | **elementary OS** | [Founder Statement planning to implement](https://mastodon.social/@danirabbit@mastodon.online/116250766314705297) |
-| :building_construction: | **Fedora** | [Planning Discussion](https://x.com/LundukeJournal/status/2036526650154729543) |
-| :building_construction: | **Debian** | [Will help downstream distros to implement](https://x.com/LundukeJournal/status/2040523897431368158) |
+| :building_construction: | **Fedora** | [Planning Discussion](https://discussion.fedoraproject.org/t/a-practical-architectural-solution-to-os-level-age-verification-laws/183387/26) ([𝕏](https://x.com/LundukeJournal/status/2036526650154729543)) |
+| :building_construction: | **Debian** | [Will help downstream distros to implement](https://lists.debian.org/debian-devel-announce/2026/04/msg00001.html) ([𝕏](https://x.com/LundukeJournal/status/2040523897431368158)) |
 
 ### Uncertain Age Verification Future
 
@@ -49,9 +49,9 @@ The developers or publishers of these open source Operating Systems have made st
 
 | &nbsp; | Operating System | Notes |
 | - | - | - |
-| :question: | **CachyOS** | [Developer statement](https://x.com/LundukeJournal/status/2037217859739542005) |
-| :question: | **MX Linux** | [Developer statement](https://x.com/LundukeJournal/status/2038279978907758664) |
-| :question: | **Solus** | [Developer statement](https://x.com/LundukeJournal/status/2042272320127971604) |
+| :question: | **CachyOS** | [Developer statement](https://discuss.cachyos.org/t/age-verification-systemd/26316) ([𝕏](https://x.com/LundukeJournal/status/2037217859739542005)) |
+| :question: | **MX Linux** | [Developer statement](https://mxlinux.org/blog/mx-news-week-ending-march-28-2026/) ([𝕏](https://x.com/LundukeJournal/status/2038279978907758664)) |
+| :question: | **Solus** | [Developer statement](https://getsol.us/2026/04/solus-and-age-verification/) ([𝕏](https://x.com/LundukeJournal/status/2042272320127971604)) |
 
 ### Operating Systems Which Have Already Implemented Age Verification
 
@@ -59,4 +59,4 @@ The following Operating Systems have officially added default Age Verification (
 
 | &nbsp; | Operating System | Notes |
 | - | - | - |
-| :identification_card: | **Midnight BSD** | [License temporarily forbids usage in Brazil, California](https://x.com/midnightbsd/status/2030992394703732872), [but Age Attestation added by default](https://x.com/LundukeJournal/status/2039377663026926005) |
+| :identification_card: | **Midnight BSD** | [License temporarily forbids usage in Brazil, California](https://x.com/midnightbsd/status/2030992394703732872), [but Age Attestation added by default](https://github.com/MidnightBSD/src/releases/tag/4.0.4) ([𝕏](https://x.com/LundukeJournal/status/2039377663026926005)) |


### PR DESCRIPTION
**Without removing original URLs**, added direct URLs to referenced/relevant posts/publications, unless the original URL is the source itself. Using 𝕏 to denote original Lunduke Journal posts on X, but substituting for something else if need be is easy.

Solves #22, #60 and #79.

For additional context, while Lunduke Journal X posts give editor's insight into why an OS was added to the corresponding column, X is not a libre service, and getting to the actual source requires the extra step of opening the X post first, if the source was linked to begin with.

Other than fixing a typo, nothing else was edited.